### PR TITLE
Choose custom installation prefix and python version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,9 @@
-PYTHON=python
-VIMDIR=/usr/share/vim/addons
-VIMPLUGINDIR=/usr/share/vim/registry
+PYTHON ?= python
+PREFIX ?= /usr/local
+VIMDIR ?= $(PREFIX)/share/vim/addons
+VIMPLUGINDIR ?= $(PREFIX)/share/vim/registry
+PYTHON_VERSION = $(shell $(PYTHON) -c 'import sys; print("%s.%s" % sys.version_info[0:2])')
+PYTHONPATH ?= $(PREFIX)/lib/python$(PYTHON_VERSION)/site-packages/
 
 .PHONY: vim
 
@@ -15,29 +18,31 @@ all: docs build
 docs: README.html
 
 build: README.rst
-	${PYTHON} setup.py build
+	PYTHONPATH="$(PYTHONPATH)" "${PYTHON}" setup.py build
 
 install: vim_plugin README.rst
-	${PYTHON} setup.py install
+	mkdir -p $(PYTHONPATH)
+	PYTHONPATH="$(PYTHONPATH)" "${PYTHON}" setup.py install --prefix=$(PREFIX)
 
 uninstall: README.rst
-	${PYTHON} setup.py uninstall
+	PYTHONPATH="$(PYTHONPATH)" "${PYTHON}" setup.py uninstall --prefix=$(PREFIX)
 
 clean:
-	${PYTHON} setup.py clean
+	PYTHONPATH="$(PYTHONPATH)" "${PYTHON}" setup.py clean
 
 distclean: clean
 	rm README.rst
 
 check:
-	PYTHON=${PYTHON} ./run_tests.sh
+	PYTHONPATH="$(PYTHONPATH)" PYTHON="${PYTHON}" ./run_tests.sh
 
 vim:
-	mkdir -pv ${VIMDIR}/syntax
-	cp -v vim/syntax/*.vim ${VIMDIR}/syntax
-	mkdir -pv ${VIMDIR}/ftdetect
-	cp -v vim/ftdetect/*.vim ${VIMDIR}/ftdetect
+	mkdir -pv "$(VIMDIR)/syntax"
+	cp -v vim/syntax/*.vim "$(VIMDIR)/syntax"
+	mkdir -pv "$(VIMDIR)/ftdetect"
+	cp -v vim/ftdetect/*.vim "$(VIMDIR)/ftdetect"
 
 vim_plugin: vim
-	mkdir -pv ${VIMPLUGINDIR}
-	cp -v vim/registry/*.yaml ${VIMPLUGINDIR}
+	mkdir -pv "$(VIMPLUGINDIR)"
+	cp -v vim/registry/*.yaml "$(VIMPLUGINDIR)"
+

--- a/README.md
+++ b/README.md
@@ -59,6 +59,17 @@ built by running:
 
 This build step depends on `pandoc` to create the RST file from `README.md`.
 
+The `Makefile` respects the following environment variables:
+
+| Variable  | Description |
+|-----------|-------------|
+| PYTHON    | Choose the python binary (e.g. `python`, `python3`, `/path/to/python`) |
+| PREFIX    | Where to install the `cmudict-tool` library, program and python modules. |
+
+If you use a custom prefix, you may need to adjust your `PYTHONPATH` environment variable
+when running `cmudict-tools`, so it can find the python module.
+
+
 The `Makefile` provides the following standard GNU commands that make it easier
 to run the setup script:
 


### PR DESCRIPTION
This PR lets the user who builds the cmudict-tools the option to provide environment variables for custom prefix installation and python version selection, instead of hardcoding them in the Makefile.

It also fixes some errors if there are spaces in some directories.

(Tested on a GNU/Linux system)